### PR TITLE
Fixed navigationViewStyle and wrapped controller presentationStyle for iPad

### DIFF
--- a/Sharing/Views/CloudSharingView.swift
+++ b/Sharing/Views/CloudSharingView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import UIKit
 import CloudKit
 
-/// This struct wraps a `UIImagePickerController` for use in SwiftUI.
+/// This struct wraps a `UICloudSharingController` for use in SwiftUI.
 struct CloudSharingView: UIViewControllerRepresentable {
 
     // MARK: - Properties

--- a/Sharing/Views/CloudSharingView.swift
+++ b/Sharing/Views/CloudSharingView.swift
@@ -25,6 +25,7 @@ struct CloudSharingView: UIViewControllerRepresentable {
         let sharingController = UICloudSharingController(share: share, container: container)
         sharingController.availablePermissions = [.allowReadWrite, .allowPrivate]
         sharingController.delegate = context.coordinator
+        sharingController.modalPresentationStyle = .formSheet
         return sharingController
     }
 

--- a/Sharing/Views/ContentView.swift
+++ b/Sharing/Views/ContentView.swift
@@ -37,6 +37,7 @@ struct ContentView: View {
                     }
                 }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
         .onAppear { vm.initialize() }
         .sheet(isPresented: $isAddingContact, content: {
             AddContactView(onAdd: addContact, onCancel: { isAddingContact = false })


### PR DESCRIPTION
By default iPad is using a split view so the contact list is only showing on the left in a split view. This sets an explicit `navigationViewStyle` to show the content as a single top view on iPad instead of a split view.

Related to #1 