### PR TITLE
Reuse existing CKShare if it already exists

### DIFF
--- a/Sharing/ViewModels/ViewModel.swift
+++ b/Sharing/ViewModels/ViewModel.swift
@@ -154,11 +154,11 @@ final class ViewModel: ObservableObject {
         database.add(saveOperation)
     }
 
-    /// Creates a `CKShare` and saves it to the private database in preparation to share a Contact with another user.
+    /// Fetches an existing `CKShare` on a Contact record, or creates a new one in preparation to share a Contact with another user.
     /// - Parameters:
     ///   - contact: Contact to share.
     ///   - completionHandler: Handler to process a `success` or `failure` result.
-    func createShare(contact: Contact, completionHandler: @escaping (Result<(CKShare, CKContainer), Error>) -> Void) {
+    func fetchOrCreateShare(contact: Contact, completionHandler: @escaping (Result<(CKShare, CKContainer), Error>) -> Void) {
         guard let existingShare = contact.associatedRecord.share else {
             let share = CKShare(rootRecord: contact.associatedRecord)
             share[CKShare.SystemFieldKey.title] = "Contact: \(contact.name)"

--- a/Sharing/ViewModels/ViewModel.swift
+++ b/Sharing/ViewModels/ViewModel.swift
@@ -12,7 +12,7 @@ final class ViewModel: ObservableObject {
     // MARK: - Error
 
     enum ViewModelError: Error {
-        case unknown
+        case invalidRemoteShare
     }
 
     // MARK: - State
@@ -183,7 +183,7 @@ final class ViewModel: ObservableObject {
             } else if let share = share as? CKShare {
                 completionHandler(.success((share, self.container)))
             } else {
-                completionHandler(.failure(ViewModelError.unknown))
+                completionHandler(.failure(ViewModelError.invalidRemoteShare))
             }
         }
     }

--- a/Sharing/Views/ContentView.swift
+++ b/Sharing/Views/ContentView.swift
@@ -125,7 +125,7 @@ struct ContentView: View {
     private func shareContact(_ contact: Contact) {
         isProcessingShare = true
 
-        vm.createShare(contact: contact) { result in
+        vm.fetchOrCreateShare(contact: contact) { result in
             isProcessingShare = false
 
             switch result {


### PR DESCRIPTION
If a contact is already shared we use the existing CKShare object.

fixes #5