### PR TITLE
Update SharingTests.swift

### DIFF
--- a/SharingTests/SharingTests.swift
+++ b/SharingTests/SharingTests.swift
@@ -15,7 +15,7 @@ class SharingTests: XCTestCase {
     // MARK: - Setup & Tear Down
 
     override func setUp() {
-        let expectation = self.expectation(description: "Expect ViewModel initizliation completed")
+        let expectation = self.expectation(description: "Expect ViewModel initialization completed")
 
         viewModel.initialize { result in
             expectation.fulfill()


### PR DESCRIPTION
Fix typo in a string literal in the body of the setup function.